### PR TITLE
Add project plan and progress logs

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,129 @@
+# Pathosphere Project Plan
+
+This document captures the initial design discussion for Pathosphere, a social network based on emotion words. It summarizes the mission, features, tech stack, and timeline as outlined by the AI planning session.
+
+## 1. Name & Branding
+- **Pathosphere** – *Where feelings find friends* (recommended name and tagline)
+- PathosPulse
+- EmotiPath
+- PathWave
+- Feelos
+
+## 2. Core Concept & UX
+- Users share short words or phrases that evoke feelings.
+- Home feed displays posts from followed accounts and "kindred" posts matched across languages via embeddings.
+- Posts can be liked, commented on, and shared.
+- Cross-language matching highlights related words with visual graphs.
+
+## Wireframe Sketches
+```
++---------------------+
+|  [ Feelos Logo ]    |
+|  "Share a feeling"  |
+|  __________________ |
+| | e.g., "gratitude"| |
+|  ------------------ |
+|  [ Post ]           |
++---------------------+
+```
+```
++------------------------------+
+|  Home Feed                   |
+|------------------------------|
+| ❤️  "calma"   - Ana          |
+| ❤️  "serenity" ↔ "calma"     |
+|📣 2 🗝 1                     |
+|------------------------------|
+| ❤️  "nostalgia" - Yuki       |
+|📣 5 🗝 0                     |
+| ...                          |
++------------------------------+
+```
+```
++------------------------------------+
+| Similar Feelings (graph preview)   |
+|   "felicidad" ---- "joy"           |
+|       \\            /              |
+|        "feliz"   " 한모 "          |
++------------------------------------+
+```
+
+## 3. MVP Feature List
+**Phase 0 (Week 1–4)**
+- Minimal web app to post a word/phrase and show a basic feed.
+- SQLite/PostgreSQL for storage.
+- Prototype cross-language matching offline.
+
+**Phase 1 (Week 5–8)**
+- User accounts with auth.
+- Likes, comments, notifications.
+- WebSockets for real time updates.
+
+**Phase 2 (Week 9–12)**
+- Scalable matching layer with embeddings.
+- Language detection, push notifications.
+- Visual explore page.
+
+## 4. Tech Stack Proposal
+- **Frontend**: Next.js (React) or Flutter Web.
+- **Backend**: Python + FastAPI.
+- **Database**: PostgreSQL with `pgvector`; Redis optional.
+- **ML Layer**: Sentence-transformer embeddings served via vector DB or pgvector.
+
+```
+[Frontend] <--REST/WebSocket--> [FastAPI API]
+                                |
+                                v
+                 [PostgreSQL + pgvector]
+                                |
+                                v
+                       [Redis (optional)]
+                                |
+                                v
+            [Worker / Embedding Service]
+```
+
+## 5. Repository Structure
+```
+repo-root/
+├── README.md
+├── docs/
+│   ├── adr/
+│   └── api/
+├── apps/
+│   ├── web/
+│   ├── api/
+│   └── worker/
+├── packages/
+│   ├── shared-ui/
+│   └── shared-lib/
+├── infra/
+│   ├── docker/
+│   ├── terraform/
+│   └── github/
+└── .gitignore
+```
+- Trunk-based development using feature branches and flags.
+- Pre-commit hooks and CI for linting, type checking and tests.
+
+## Local Development
+- `docker compose up` to start services.
+- `.env.example` documents required env vars; secrets managed separately.
+- Tests via `npm test`, `pytest`, and e2e with Playwright.
+
+## Deployment & Hosting
+- **MVP** hosted on Fly.io.
+- **Scale up** with Kubernetes on GKE or AWS EKS, Postgres replicas and a CDN.
+- CI/CD via GitHub Actions deploying to staging and production with zero downtime migrations.
+
+## Growth & Monetization Ideas
+- Word-challenge events and viral loops.
+- Premium graph insights and paid API for analytics.
+
+## Risks & Mitigations
+- Moderation transformer to filter abuse.
+- Prevent namespace squatting.
+- Test across right-to-left and CJK scripts.
+
+## 90-Day Timeline & Team Roles
+Week-by-week plan covers setup, features, matching service, and launch. Roles include PM, FE dev, BE dev, ML engineer, designer and DevOps.

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# Pathos
+# Pathosphere
+
+*Where feelings find friends*
+
+Pathosphere is a multilingual microblogging platform for sharing single words or short phrases that evoke feelings. Users can like, comment and share posts across languages.
+
+The repository stores planning documents and progress logs for building the MVP.
+
+- See [PLAN.md](PLAN.md) for the project roadmap.
+- Daily updates: `progress/daily/`
+- Weekly summaries: `progress/weekly/`
+
+Licensed under the MIT License.

--- a/progress/daily/2025-06-20.md
+++ b/progress/daily/2025-06-20.md
@@ -1,0 +1,6 @@
+# 2025-06-20
+
+- Initialized repository structure.
+- Added project plan and README summarizing the Pathosphere concept.
+- Set up progress tracking folders for daily and weekly notes.
+- Next: outline detailed tasks for initial MVP (database schema, basic posting API, simple frontend).

--- a/progress/weekly/2025-W25.md
+++ b/progress/weekly/2025-W25.md
@@ -1,0 +1,14 @@
+# Week 25, 2025
+
+**Goals**
+- Capture initial design ideas and repository setup.
+- Begin planning tasks for the MVP.
+
+**Progress**
+- Recorded high-level plan in PLAN.md.
+- Created README with project overview.
+- Established folders for daily and weekly progress notes.
+
+**Next Week**
+- Break down feature list into actionable issues.
+- Prototype database and API skeleton.


### PR DESCRIPTION
## Summary
- expand README with overview and tagline
- document the full project plan in PLAN.md
- add daily and weekly progress logs

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68552f4a0ca483299d9955bfa0dfc4b7