### PR TITLE
Expand task lists with detailed steps

### DIFF
--- a/tasks/tasks-phase0.md
+++ b/tasks/tasks-phase0.md
@@ -1,7 +1,18 @@
 # Phase 0 Tasks
 
-- [ ] Scaffold FastAPI backend with posts endpoints.
-- [ ] Build minimal web frontend to create and view posts.
-- [ ] Prototype cross-language matching using embeddings.
-- [ ] Provide Docker Compose for local development.
-- [ ] Add unit tests for API.
+## Backend Prototype
+- [x] Create FastAPI project skeleton
+- [x] Set up SQLite database and SQLAlchemy model for posts
+- [x] Implement POST /posts endpoint
+- [x] Implement GET /posts endpoint
+
+## Frontend Prototype
+- [x] Build simple HTML page to submit and list posts
+
+## Matching Prototype
+- [x] Add matcher module with offline embeddings search
+
+## Development Environment
+- [x] Provide Docker Compose for API and database
+- [x] Add unit tests for /posts endpoints
+

--- a/tasks/tasks-phase1.md
+++ b/tasks/tasks-phase1.md
@@ -1,0 +1,28 @@
+# Phase 1 Tasks
+
+## Authentication
+- [ ] Design `User` SQLAlchemy model with hashed password field
+- [ ] Create migration or schema update for users table
+- [ ] Implement registration endpoint
+- [ ] Implement login endpoint returning JWT token
+- [ ] Apply auth dependency to posts routes
+- [ ] Write unit tests for sign-up and login flows
+
+## Social Features
+- [ ] Add `Like` model and like/unlike endpoints
+- [ ] Add `Comment` model and CRUD endpoints
+- [ ] Implement notification table for new likes/comments
+- [ ] Provide endpoint to fetch notifications
+- [ ] Test likes, comments and notifications
+
+## Real-time Updates
+- [ ] Create WebSocket endpoint for live feed
+- [ ] Broadcast new posts and notifications via WebSocket
+- [ ] Implement simple WebSocket client in frontend
+- [ ] Integration tests for WebSocket events
+
+## Documentation & DevOps
+- [ ] Document new API routes and authentication flow
+- [ ] Update Docker Compose services for added dependencies
+- [ ] Extend README with instructions for running Phase 1 features
+

--- a/tasks/tasks-phase2.md
+++ b/tasks/tasks-phase2.md
@@ -1,0 +1,29 @@
+# Phase 2 Tasks
+
+## Matching Service
+- [ ] Package embeddings logic into a standalone service
+- [ ] Containerize sentence-transformer model
+- [ ] Provide REST endpoint for similarity queries
+- [ ] Connect API to matching service for kindred posts
+- [ ] Automated tests for matching layer
+
+## Language & Notifications
+- [ ] Integrate language detection on post creation
+- [ ] Store detected language in the database
+- [ ] Add push notification service (placeholder implementation)
+- [ ] Endpoint for registering device tokens
+- [ ] End-to-end tests for notifications flow
+
+## Explore Page
+- [ ] Add API endpoint to fetch graph of related posts
+- [ ] Create frontend page with interactive graph view
+- [ ] Include search field for exploring posts
+- [ ] Unit tests for explore endpoints
+
+## Production Readiness
+- [ ] Dockerfile for API and background workers
+- [ ] Terraform or similar templates for cloud resources
+- [ ] Configure CI workflow for build and test
+- [ ] Perform security and performance review
+- [ ] Final documentation pass
+


### PR DESCRIPTION
## Summary
- break Phase 0 tasks into subcategories
- replace Phase 1 tasks with detailed authentication, social, and devops steps
- expand Phase 2 tasks into matching, language, explore, and production sections

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_6855365f62a88329971a69645ff79d0f