### PR TITLE
Add local run instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,14 @@ The repository stores planning documents and progress logs for building the MVP.
 - Daily updates: `progress/daily/`
 - Weekly summaries: `progress/weekly/`
 
+## Running Locally
+
+1. Copy `.env.example` to `.env`.
+2. Start the API and frontend with `docker compose up`.
+   - Web: <http://localhost:3000>
+   - API docs: <http://localhost:8000/docs>
+
+Install dependencies from `apps/api/requirements.txt` if you want to run the
+tests directly and then execute `pytest`.
+
 Licensed under the MIT License.


### PR DESCRIPTION
## Summary
- explain how to launch API/web using Docker
- note how to run tests locally

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fastapi')*

------
https://chatgpt.com/codex/tasks/task_e_685540efba9883299353d95708380d35