### PR TITLE
Add GitHub Actions workflow for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,21 @@
+name: Tests
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r apps/api/requirements.txt
+      - name: Run tests
+        run: PYTHONPATH=. pytest

--- a/apps/api/requirements.txt
+++ b/apps/api/requirements.txt
@@ -4,3 +4,4 @@ sqlalchemy
 aiosqlite
 pydantic
 pytest
+httpx<0.24


### PR DESCRIPTION
## Summary
- set up GitHub Actions workflow to run pytest on push and PR
- add missing `httpx` dependency
- ensure tests run with `PYTHONPATH` set

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6856b24517d483299838445c3e5088ee